### PR TITLE
new paymentObligation contract migration to rinkeby and kovan

### DIFF
--- a/migrations/4_payment_obligations_no_signature.js
+++ b/migrations/4_payment_obligations_no_signature.js
@@ -1,0 +1,11 @@
+const AnchorRepository = artifacts.require("AnchorRepository");
+const PaymentObligation = artifacts.require("PaymentObligation");
+
+module.exports = function (deployer, network) {
+    // Redeploy PaymentObligation to rinkeby and kovan
+    return AnchorRepository.deployed().then(() => {
+        if(network == 'rinkeby' || network == 'kovan')
+            return deployer.deploy(PaymentObligation, AnchorRepository.address);
+    });
+
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/ethereum-contracts",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Centrifuge OS (https://github.com/centrifuge/centrifuge-ethereum-contracts)",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- in the latest version, we are not using the signature parameter for the mint method anymore
- we need to redeploy the contracts